### PR TITLE
AM-4834: Fix minor typos in tutorials doc

### DIFF
--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
@@ -1,4 +1,4 @@
-# Deploying the BookInfo Application on an Intra-cluster Slice
+# Deploying the Bookinfo Application on an Intra-cluster Slice
 
 ## Introduction
 [Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
@@ -446,10 +446,10 @@ Perform these steps:
    serviceexport.networking.kubeslice.io/reviews created
    ```
 :::info
-This completes the deployment of Bookinfo Application on a Slice.**
+This completes the deployment of Bookinfo application on a slice.**
 :::
 
-## Validating the BookInfo Deployment
+## Validating the Bookinfo Deployment
 ### Validating the Services
 
 Perform these steps:
@@ -471,7 +471,7 @@ KubeSlice configuration:
    reviews   white             9080/TCP   1           READY
    ```
 
-## Validating the Product Page on the Cloud Cluster
+## Validating the Productpage on the Cloud Cluster
 
 Perform these steps:
 
@@ -528,8 +528,8 @@ and visit the page in a browser to view your multi-cluster Bookinfo deployment.
    Example
    ![alt](/img/Bookinfo-productpage-OS.png)
 
-## Validating the Product Page on the Kind Cluster
-### Accessing the Product Page from the Local Machine
+## Validating the Productpage on the Kind Cluster
+### Accessing the Productpage from the Local Machine
 If the kind clusters are on a local machine, perform these steps:
 
 1. Set up port-forwarding from a local machine using the following command:
@@ -552,7 +552,7 @@ If the kind clusters are on a local machine, perform these steps:
 The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
-### Accessing the Product Page from the Cloud EC2 Machine
+### Accessing the Productpage from the Cloud EC2 Machine
 If the kind clusters are on Cloud EC2 Machine, perform these steps:
 
 1. Connect to your EC2 machine using SSH from your local machine using the following command:
@@ -579,6 +579,6 @@ The following is an example of the product page:
 You have successfully deployed the Bookinfo application on a KubeSlice configuration containing at least two clusters.
 :::
 
-## Uninstalling Istio BookInfo
+## Uninstalling Istio Bookinfo
 To uninstall Istio Bookinfo from your KubeSlice configuration, follow the instructions 
 in [offboarding namespaces](/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/uninstalling-kubeslice/offboarding-namespaces.mdx).

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
@@ -15,8 +15,8 @@ see [Installing KubeSlice](/versioned_docs/version-0.2.0/getting-started-with-cl
   ```
   kubectl create ns Bookinfo
   ```
-## Creating the Slice
-To install the BookInfo Application on a single cluster, you must create a slice without Istio. For more information, 
+## Creating a Slice
+To install the BookInfo Application on a single cluster, you must create a slice without Istio enabled. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
 ## Creating the BookInfo Deployment YAML Files

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
@@ -1,9 +1,9 @@
 # Deploying the BookInfo Application on an Intra-cluster Slice
 
 ## Introduction
-[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio composed of four separate 
-microservices productpage, details, reviews, and ratings. This topic describes the steps to install the Bookinfo 
-application on a single cluster.
+[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
+of four separate microservices: productpage, details, reviews, and ratings. In this topic, we will use 
+the Bookinfo application to demonstrate inter-slice communication.
 
 ## Prerequisites
 Before you begin, ensure the following prerequisites are met:
@@ -19,7 +19,7 @@ see [Installing KubeSlice](/versioned_docs/version-0.2.0/getting-started-with-cl
 To install the BookInfo Application on a single cluster, you must create a slice without Istio. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
-## Creating the Bookinfo Deployment YAML Files
+## Creating the BookInfo Deployment YAML Files
 Using the templates below, create the necessary .yaml files to deploy the Bookinfo application. All fields in the 
 template will remain the same except for the `slice name` which must be replaced with the name of your slice.
 
@@ -446,7 +446,7 @@ Perform these steps:
    serviceexport.networking.kubeslice.io/reviews created
    ```
 :::info
-This completes the deployment of Bookinfo Appication on a Slice.**
+This completes the deployment of Bookinfo Application on a Slice.**
 :::
 
 ## Validating the BookInfo Deployment
@@ -532,7 +532,7 @@ and visit the page in a browser to view your multi-cluster Bookinfo deployment.
 ### Accessing the Product Page from the Local Machine
 If the kind clusters are on a local machine, perform these steps:
 
-1. set up port-forwarding from a local machine using the following command:
+1. Set up port-forwarding from a local machine using the following command:
    ```
    kubectl port-forward svc/<service-name> -n <namespace-name> <host-port>:<container-port>
    ```
@@ -576,7 +576,7 @@ The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
 :::success
-You have successfully deployed Bookinfo application on a KubeSlice configuration containing at least two clusters.
+You have successfully deployed the Bookinfo application on a KubeSlice configuration containing at least two clusters.
 :::
 
 ## Uninstalling Istio BookInfo

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
@@ -1,9 +1,9 @@
 # Deploying the BookInfo Application
 
 ## Introduction
-[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio composed of four separate 
-microservices intended to demonstrate various Istio features. In this topic, we will use Istio Bookinfo to demonstrate 
-inter-slice communications.
+[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
+of four separate microservices: productpage, details, reviews, and ratings. In this topic, we will use the 
+Bookinfo application to demonstrate inter-slice communication.
 
 ## Prerequisites
 Before you begin, ensure the following prerequisites are met:
@@ -24,7 +24,7 @@ see [Installing Istio](/versioned_docs/version-0.2.0/getting-started-with-cloud-
 - You have the slice created across worker clusters. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
-## Creating the Bookinfo Deployment YAML Files
+## Creating the BookInfo Deployment YAML Files
 Using the templates below, create the necessary .yaml files to deploy the Bookinfo application.
 All fields in the template will remain the same except for the `slice name` which must be replaced with the 
 name of your slice.
@@ -587,7 +587,7 @@ The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
 :::success
-You have successfully deployed Bookinfo applicaiton on a KubeSlice configuration containing at least two clusters.
+You have successfully deployed Bookinfo application on a KubeSlice configuration containing at least two clusters.
 :::
 
 ## Uninstalling Istio BookInfo

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
@@ -1,4 +1,4 @@
-# Deploying the BookInfo Application
+# Deploying the Bookinfo Application
 
 ## Introduction
 [Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
@@ -24,7 +24,7 @@ see [Installing Istio](/versioned_docs/version-0.2.0/getting-started-with-cloud-
 - You have the slice created across worker clusters. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
-## Creating the BookInfo Deployment YAML Files
+## Creating the Bookinfo Deployment YAML Files
 Using the templates below, create the necessary .yaml files to deploy the Bookinfo application.
 All fields in the template will remain the same except for the `slice name` which must be replaced with the 
 name of your slice.
@@ -461,7 +461,7 @@ Use the following command to apply the `details.yaml` file.
    serviceexport.networking.kubeslice.io/reviews created
    ```
 
-## Validating the BookInfo Deployment
+## Validating the Bookinfo Deployment
 ### Validating the Services
 
 Perform these steps:
@@ -482,7 +482,7 @@ KubeSlice configuration:
    details   white   true      9080/TCP   1           READY
    reviews   white   true      9080/TCP   1           READY
    ```
-### Validating the Product Page on the Cloud Cluster
+### Validating the Productpage on the Cloud Cluster
 
 Perform these steps:
 
@@ -539,8 +539,8 @@ and visit the page in a browser to view your multi-cluster Bookinfo deployment.
    Example
    ![alt](/img/Bookinfo-productpage-OS.png)
 
-## Validating the Product Page on the Kind Cluster
-### Accessing the Product Page from the Local Machine
+## Validating the Productpage on the Kind Cluster
+### Accessing the Productpage from the Local Machine
 If the kind clusters are on a local machine, perform these steps:
 
 1. Set up port-forwarding from a local machine using the following command:
@@ -563,7 +563,7 @@ If the kind clusters are on a local machine, perform these steps:
 The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
-### Accessing the Product Page from the Cloud EC2 Machine
+### Accessing the Productpage from the Cloud EC2 Machine
 If the kind clusters are on Cloud EC2 Machine, perform these steps:
 
 1. Connect to your EC2 machine using SSH from your local machine using the following command:
@@ -590,6 +590,6 @@ The following is an example of the product page:
 You have successfully deployed Bookinfo application on a KubeSlice configuration containing at least two clusters.
 :::
 
-## Uninstalling Istio BookInfo
+## Uninstalling Istio Bookinfo
 To uninstall Bookinfo application from your KubeSlice configuration, follow the 
 instructions in [offboarding namespaces](/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/uninstalling-kubeslice/offboarding-namespaces.mdx).

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
@@ -35,7 +35,7 @@ the `productpage cluster`, and the remaining services as well as service exports
 referred to here as the `services cluster`.
 :::
 
-## Product Page
+## Productpage
 Using the template below, create productpage.yaml. All fields in the template will remain the same except for 
 the `slice name` which must be replaced with the name of your slice.
 ```

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
@@ -13,17 +13,17 @@ Before you begin, ensure the following prerequisites are met:
 
 - You have the KubeSlice Controller components and Worker cluster components on the same cluster. For more information, 
 see [Installing KubeSlice](/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/installing-kubeslice/installing-kubeslice.mdx).
-- Before creating the slice, create a `iperf` namespace in all participating worker clusters.
+- Before creating a slice, create the `iperf` namespace in all participating worker clusters.
 Use the following command to create the `iperf` namespace:
   ```
   kubectl create ns iperf
   ```
 
-## Creating the Slice
-To install the iPerf application on a single cluster, you must create a slice without Istio.
+## Creating a Slice
+To install the iPerf application on a single cluster, you must create a slice without Istio enabled.
 
-### Creating the Slice Configuration YAML File
-Use the following template to create a slice without Istio:
+### Creating a Slice Configuration YAML File
+Use the following template to create a slice without Istio enabled:
 ```
 apiVersion: controller.kubeslice.io/v1alpha1
 kind: SliceConfig

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
@@ -64,9 +64,9 @@ The following information is required.
 
 | Variable | Description |
 |------------|------------------------|
-| **cluster name** | The name of the cluster. |
-| **slice configuration**| The name of the slice configuration file. |
-| **project name** | The project name on which you apply the slice configuration file. |
+| `<cluster name>` | The name of the cluster. |
+| `<slice configuration>`| The name of the slice configuration file. |
+| `<project name>` | The project name on which you apply the slice configuration file. |
 
 Perform these steps:
 

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
@@ -259,7 +259,7 @@ Perform these steps:
    ```
 
 ## Validating ServiceExportconfig and ServiceImportconfig
-Perform these steps in the worker cluster where KubeSlice Controller is installed:
+Perform these steps on the worker cluster where KubeSlice Controller is installed:
 
 1. Switch the context of the cluster.
    ```
@@ -317,7 +317,7 @@ Perform these steps:
    
 Example Output
 
-If the iperf-sleep pod is able to reach the iperf-server pod , you should see similar output to that below.
+If the iperf-sleep pod is able to reach the iperf-server pod, you should see similar output to that below.
 ```
 > kubectl exec -it iperf-sleep-5477bf94cb-vmmtd -c iperf -n iperf -- sh
 / $ iperf -c iperf-server.iperf.svc.slice.local -p 5201 -i 1 -b 10Mb;

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
@@ -63,9 +63,9 @@ The following information is required.
 
 | Variable     |  Description |
 |---------------|--------------------------------|
-| **cluster name** | The given name of the cluster. |
-| **slice configuration** | The name of the slice configuration file |
-| **project namespace** | The project namespace on which you apply the slice configuration file. |
+| `<cluster name>` | The given name of the cluster. |
+| `<slice configuration>` | The name of the slice configuration file |
+| `<project namespace>` | The project namespace on which you apply the slice configuration file. |
 
 Perform these steps:
 

--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
@@ -125,7 +125,7 @@ spec:
 
 Perform these steps:
 
-1. Switch the context to the registered cluster you want to install Iperf-sleep. 
+1. Switch the context to the registered cluster you want to install iperf-sleep. 
    ```
    kubectx <cluster name>
    ```
@@ -200,7 +200,7 @@ spec:
 ### Applying the iPerf Server YAML File
 Perform these steps:
 
-1. Switch context to the registered cluster you want to install the iperf server.
+1. Switch the context to the registered cluster you want to install the iperf server.
    ```
    kubectx <cluster name>
    ```
@@ -280,7 +280,7 @@ Perform these steps:
    ```
 
 ## Validating ServiceExport and ServiceImport
-Perform these steps in the cluster where KubeSlice Controller is installed:
+Perform these steps on the cluster where KubeSlice Controller is installed:
 
 1. Switch the context of the cluster.
    ```

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
@@ -10,13 +10,13 @@ Before you begin, ensure the following prerequisites are met:
 
 - You have the KubeSlice Controller components and worker cluster components on the same cluster. For more information, 
 see [Installing KubeSlice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/installing-kubeslice.mdx).
-- Before creating the slice, create a `bookinfo` namespace in all participating worker.
+- Before creating a slice, create the `bookinfo` namespace in all the participating worker clusters.
   Use the following command to create the `bookinfo` namespace:
   ```
   kubectl create ns Bookinfo
   ```
 ## Creating the Slice
-To install the BookInfo Application on a single cluster, you must create a slice without Istio. For more information, 
+To install the Bookinfo application on a single cluster, you must create a slice without Istio enabled. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
 ## Creating the BookInfo Deployment YAML Files
@@ -24,7 +24,7 @@ Using the templates below, create the necessary .yaml files to deploy the Bookin
 template will remain the same except for the `slice name` which must be replaced with the name of your slice.
 
 :::info
-These instructions will guide you through deploying the Product Page service to a cluster we will refer to as 
+These instructions will guide you through deploying the Productpage service to a cluster we will refer to as 
 the `productpage cluster`, and the remaining services as well as service exports will be deployed to a 
 cluster referred to here as the `services cluster`.
 :::
@@ -471,7 +471,7 @@ KubeSlice configuration:
    reviews   white             9080/TCP   1           READY
    ```
 
-## Validating the Product Page on the Cloud Cluster
+## Validating the Productpage on the Cloud Cluster
 
 Perform these steps:
 
@@ -552,7 +552,7 @@ If the kind clusters are on a local machine, perform these steps:
 The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
-### Accessing the Product Page from the Cloud EC2 Machine
+### Accessing the Productpage from the Cloud EC2 Machine
 If the kind clusters are on Cloud EC2 Machine, perform these steps:
 
 1. Connect to your EC2 machine using SSH from your local machine using the following command:
@@ -579,6 +579,6 @@ The following is an example of the product page:
 You have successfully deployed the Bookinfo application on a KubeSlice configuration containing at least two clusters.
 :::
 
-## Uninstalling Istio BookInfo
+## Uninstalling Istio Bookinfo
 To uninstall Istio Bookinfo from your KubeSlice configuration, follow the instructions 
 in [offboarding namespaces](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/uninstalling-kubeslice/offboarding-namespaces.mdx).

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
@@ -1,9 +1,9 @@
 # Deploying the BookInfo Application on an Intra-cluster Slice
 
 ## Introduction
-[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio composed of four separate 
-microservices productpage, details, reviews, and ratings. This topic describes the steps to install the Bookinfo 
-application on a single cluster.
+[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
+of four separate microservices: productpage, details, reviews, and ratings. In this topic, we will use the 
+Bookinfo application to demonstrate inter-slice communication.
 
 ## Prerequisites
 Before you begin, ensure the following prerequisites are met:
@@ -19,7 +19,7 @@ see [Installing KubeSlice](/versioned_docs/version-0.3.0/getting-started-with-cl
 To install the BookInfo Application on a single cluster, you must create a slice without Istio. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
-## Creating the Bookinfo Deployment YAML Files
+## Creating the BookInfo Deployment YAML Files
 Using the templates below, create the necessary .yaml files to deploy the Bookinfo application. All fields in the 
 template will remain the same except for the `slice name` which must be replaced with the name of your slice.
 
@@ -446,7 +446,7 @@ Perform these steps:
    serviceexport.networking.kubeslice.io/reviews created
    ```
 :::info
-This completes the deployment of Bookinfo Appication on a Slice.**
+This completes the deployment of Bookinfo Application on a Slice.**
 :::
 
 ## Validating the BookInfo Deployment
@@ -511,7 +511,7 @@ visit the Bookinfo webpage.
    ```
    kubectl get nodes -o wide
    ```
-   Expected Output (your output will differ, here we are just focused on the external IP value).
+   Expected Output (your output will differ, here we are just focused on the external IP address).
    ```
    kubectl get nodes -o wide
    NAME                                                  STATUS   ROLES    AGE   VERSION             INTERNAL-IP   EXTERNAL-IP      OS-IMAGE
@@ -532,7 +532,7 @@ and visit the page in a browser to view your multi-cluster Bookinfo deployment.
 ### Accessing the Product Page from the Local Machine
 If the kind clusters are on a local machine, perform these steps:
 
-1. set up port-forwarding from a local machine using the following command:
+1. Set up port-forwarding from a local machine using the following command:
    ```
    kubectl port-forward svc/<service-name> -n <namespace-name> <host-port>:<container-port>
    ```
@@ -576,7 +576,7 @@ The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
 :::success
-You have successfully deployed Bookinfo application on a KubeSlice configuration containing at least two clusters.
+You have successfully deployed the Bookinfo application on a KubeSlice configuration containing at least two clusters.
 :::
 
 ## Uninstalling Istio BookInfo

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application-on-an-intra-cluster-slice.mdx
@@ -1,4 +1,4 @@
-# Deploying the BookInfo Application on an Intra-cluster Slice
+# Deploying the Bookinfo Application on an Intra-cluster Slice
 
 ## Introduction
 [Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
@@ -29,7 +29,7 @@ the `productpage cluster`, and the remaining services as well as service exports
 cluster referred to here as the `services cluster`.
 :::
 
-## Product Page
+## ProductPage
 Using the template below, create productpage.yaml. All fields in the template will remain the same except for 
 the `slice name` which must be replaced with the name of your slice.
 ```
@@ -445,11 +445,11 @@ Perform these steps:
    serviceexport.networking.kubeslice.io/details created
    serviceexport.networking.kubeslice.io/reviews created
    ```
-:::info
-This completes the deployment of Bookinfo Application on a Slice.**
+:::success
+You have completed the deployment of Bookinfo application on a slice.**
 :::
 
-## Validating the BookInfo Deployment
+## Validating the Bookinfo Deployment
 ### Validating the Services
 
 Perform these steps:
@@ -528,8 +528,8 @@ and visit the page in a browser to view your multi-cluster Bookinfo deployment.
    Example
    ![alt](/img/Bookinfo-productpage-OS.png)
 
-## Validating the Product Page on the Kind Cluster
-### Accessing the Product Page from the Local Machine
+## Validating the Productpage on the Kind Cluster
+### Accessing the Productpage from the Local Machine
 If the kind clusters are on a local machine, perform these steps:
 
 1. Set up port-forwarding from a local machine using the following command:

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
@@ -1,9 +1,9 @@
 # Deploying the BookInfo Application
 
 ## Introduction
-[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio composed of four separate 
-microservices intended to demonstrate various Istio features. In this topic, we will use Istio Bookinfo to demonstrate 
-inter-slice communications.
+[Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
+of four separate microservices: productpage, details, reviews, and ratings. In this topic, we will use the 
+Bookinfo application to demonstrate inter-slice communication.
 
 ## Prerequisites
 Before you begin, ensure the following prerequisites are met:
@@ -24,7 +24,7 @@ see [Installing Istio](/versioned_docs/version-0.3.0/getting-started-with-cloud-
 - You have the slice created across worker clusters. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
-## Creating the Bookinfo Deployment YAML Files
+## Creating the BookInfo Deployment YAML Files
 Using the templates below, create the necessary .yaml files to deploy the Bookinfo application.
 All fields in the template will remain the same except for the `slice name` which must be replaced with the 
 name of your slice.

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
@@ -12,7 +12,7 @@ Before you begin, ensure the following prerequisites are met:
 see [Installing KubeSlice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/installing-kubeslice.mdx).
 - You have Istio installed in all registered worker clusters. For more information, 
 see [Installing Istio](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx#installing-istio).
-- Before creating the slice, create a `bookinfo` namespace in all participating worker clusters.
+- Before creating a slice, create the `bookinfo` namespace in all the participating worker clusters.
   Use the following command to create the `bookinfo` namespace:
   ```
   kubectl create ns bookinfo
@@ -21,7 +21,7 @@ see [Installing Istio](/versioned_docs/version-0.3.0/getting-started-with-cloud-
   ```
   kubectl label namespace bookinfo istio-injection=enabled
   ```
-- You have the slice created across worker clusters. For more information, 
+- You have the slice created across the worker clusters. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
 ## Creating the Bookinfo Deployment YAML Files
@@ -531,7 +531,7 @@ port we just retrieved.Take note of the external IP address of one of the applic
    gke-preprod-knative--preprod-knative--aba5a0cc-xj3j   Ready    <none>   27h   v1.20.15-gke.3600   10.6.0.5      35.243.229.81    Container-Optimized OS from Google   5.4.170+         containerd://1.4.8
    gke-preprod-knative--preprod-knative--d19d3a9f-c32x   Ready    <none>   28h   v1.20.15-gke.3600   10.6.0.3      104.196.200.27   Container-Optimized OS from Google   5.4.170+         containerd://1.4.8
    ```
-5. Combine the external IP the command returns with the port you retrieved in the last step in the format below, 
+5. Combine the external IP address the command returns with the port you retrieved in the last step in the format below, 
 and visit the page in a browser to view your multi-cluster Bookinfo deployment.
    ```
    http://<external ip>:<port>/productpage
@@ -587,7 +587,7 @@ The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
 :::success
-You have successfully deployed Bookinfo applicaiton on a KubeSlice configuration containing at least two clusters.
+You have successfully deployed Bookinfo application on a KubeSlice configuration containing at least two clusters.
 :::
 
 ## Uninstalling Istio Bookinfo

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-bookinfo-application.mdx
@@ -1,4 +1,4 @@
-# Deploying the BookInfo Application
+# Deploying the Bookinfo Application
 
 ## Introduction
 [Bookinfo](https://istio.io/latest/docs/examples/bookinfo/) is a sample application from Istio that is composed 
@@ -24,7 +24,7 @@ see [Installing Istio](/versioned_docs/version-0.3.0/getting-started-with-cloud-
 - You have the slice created across worker clusters. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
-## Creating the BookInfo Deployment YAML Files
+## Creating the Bookinfo Deployment YAML Files
 Using the templates below, create the necessary .yaml files to deploy the Bookinfo application.
 All fields in the template will remain the same except for the `slice name` which must be replaced with the 
 name of your slice.
@@ -35,7 +35,7 @@ the `productpage cluster`, and the remaining services as well as service exports
 referred to here as the `services cluster`.
 :::
 
-## Product Page
+## Productpage
 Using the template below, create productpage.yaml. All fields in the template will remain the same except for 
 the `slice name` which must be replaced with the name of your slice.
 ```
@@ -366,7 +366,7 @@ spec:
    containerPort: 9080
    protocol: TCP
 ```
-## Deploying to the Product Page Cluster
+## Deploying to the Productpage Cluster
 
 Perform these steps:
 1. Use the following command to ensure we are targeting the cluster we will be deploying the product page to:
@@ -461,7 +461,7 @@ Use the following command to apply the `details.yaml` file.
    serviceexport.networking.kubeslice.io/reviews created
    ```
 
-## Validating the BookInfo Deployment
+## Validating the Bookinfo Deployment
 ### Validating the Services
 
 Perform these steps:
@@ -482,7 +482,7 @@ KubeSlice configuration:
    details   white   true      9080/TCP   1           READY
    reviews   white   true      9080/TCP   1           READY
    ```
-### Validating the Product Page on the Cloud Cluster
+### Validating the Productpage on the Cloud Cluster
 
 Perform these steps:
 
@@ -539,8 +539,8 @@ and visit the page in a browser to view your multi-cluster Bookinfo deployment.
    Example
    ![alt](/img/Bookinfo-productpage-OS.png)
 
-## Validating the Product Page on the Kind Cluster
-### Accessing the Product Page from the Local Machine
+## Validating the Productpage on the Kind Cluster
+### Accessing the Productpage from the Local Machine
 If the kind clusters are on a local machine, perform these steps:
 
 1. Set up port-forwarding from a local machine using the following command:
@@ -563,7 +563,7 @@ If the kind clusters are on a local machine, perform these steps:
 The following is an example of the product page:
 ![alt](/img/Bookinfo-productpage-OS.png)
 
-### Accessing the Product Page from the Cloud EC2 Machine
+### Accessing the Productpage from the Cloud EC2 Machine
 If the kind clusters are on Cloud EC2 Machine, perform these steps:
 
 1. Connect to your EC2 machine using SSH from your local machine using the following command:
@@ -590,6 +590,6 @@ The following is an example of the product page:
 You have successfully deployed Bookinfo applicaiton on a KubeSlice configuration containing at least two clusters.
 :::
 
-## Uninstalling Istio BookInfo
+## Uninstalling Istio Bookinfo
 To uninstall Bookinfo application from your KubeSlice configuration, follow the 
 instructions in [offboarding namespaces](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/uninstalling-kubeslice/offboarding-namespaces.mdx).

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
@@ -11,19 +11,19 @@ This tutorial provides the steps to:
 ## Prerequisites
 Before you begin, ensure the following prerequisites are met:
 
-- You have the KubeSlice Controller components and Worker cluster components on the same cluster. For more information, 
+- You have the KubeSlice Controller components and worker cluster components on the same cluster. For more information, 
 see [Installing KubeSlice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/installing-kubeslice.mdx).
-- Before creating the slice, create a `iperf` namespace in all participating worker clusters.
+- Before creating a slice, create the `iperf` namespace in all the participating worker clusters.
 Use the following command to create the `iperf` namespace:
   ```
   kubectl create ns iperf
   ```
 
-## Creating the Slice
-To install the iPerf application on a single cluster, you must create a slice without Istio.
+## Creating a Slice
+To install the iPerf application on a single cluster, you must create a slice without Istio enabled.
 
 ### Creating the Slice Configuration YAML File
-Use the following template to create a slice without Istio:
+Use the following template to create a slice without Istio enabled:
 ```
 apiVersion: controller.kubeslice.io/v1alpha1
 kind: SliceConfig

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
@@ -317,7 +317,7 @@ Perform these steps:
    
 Example Output
 
-If the iperf-sleep pod is able to reach the iperf-server pod , you should see similar output to that below.
+If the iperf-sleep pod is able to reach the iperf-server pod, you should see similar output to that below.
 ```
 > kubectl exec -it iperf-sleep-5477bf94cb-vmmtd -c iperf -n iperf -- sh
 / $ iperf -c iperf-server.iperf.svc.slice.local -p 5201 -i 1 -b 10Mb;

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application-on-an-intra-cluster-slice.mdx
@@ -64,9 +64,9 @@ The following information is required.
 
 | Variable | Description |
 |------------|------------------------|
-| **cluster name** | The name of the cluster. |
-| **slice configuration**| The name of the slice configuration file. |
-| **project name** | The project name on which you apply the slice configuration file. |
+| `<cluster name>` | The name of the cluster. |
+| `<slice configuration>`| The name of the slice configuration file. |
+| `<project name>` | The project name on which you apply the slice configuration file. |
 
 Perform these steps:
 
@@ -259,7 +259,7 @@ Perform these steps:
    ```
 
 ## Validating ServiceExportconfig and ServiceImportconfig
-Perform these steps in the worker cluster where KubeSlice Controller is installed:
+Perform these steps on the worker cluster where KubeSlice Controller is installed:
 
 1. Switch the context of the cluster.
    ```
@@ -288,7 +288,7 @@ Perform these steps in the worker cluster where KubeSlice Controller is installe
 ## Getting the DNS Name
 
 Use the following command to describe the iperf-server service and retrieve the short and full DNS names for the 
-service. We will use the short DNS name later to verify the inter-cluster communication.
+service. Use the short DNS name later to verify the inter-cluster communication.
 
 ```
 kubectl describe serviceimport iperf-server -n iperf | grep "Dns Name:"

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
@@ -125,7 +125,7 @@ spec:
 
 Perform these steps:
 
-1. Switch the context to the registered cluster you want to install Iperf-sleep. 
+1. Switch the context to the registered cluster you want to install iperf-sleep. 
    ```
    kubectx <cluster name>
    ```
@@ -190,7 +190,7 @@ spec:
  selector:
    matchLabels:
      app: iperf-server
-     ingressEnabled: false
+ ingressEnabled: false
  ports:
  - name: tcp
    containerPort: 5201

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
@@ -63,9 +63,9 @@ The following information is required.
 
 | Variable     |  Description |
 |---------------|--------------------------------|
-| **cluster name** | The given name of the cluster. |
-| **slice configuration** | The name of the slice configuration file |
-| **project namespace** | The project namespace on which you apply the slice configuration file. |
+| `<cluster name>` | The given name of the cluster. |
+| `<slice configuration>` | The name of the slice configuration file |
+| `<project namespace>` | The project namespace on which you apply the slice configuration file. |
 
 Perform these steps:
 
@@ -200,7 +200,7 @@ spec:
 ### Applying the iPerf Server YAML File
 Perform these steps:
 
-1. Switch context to the registered cluster you want to install the iperf server.
+1. Switch the context to the registered cluster you want to install the iperf server.
    ```
    kubectx <cluster name>
    ```
@@ -214,7 +214,7 @@ Perform these steps:
    ```
 
 ## Validating your iPerf Installation
-To verify our iPerf installation, first switch contexts to the cluster with the iperf-sleep.yaml applied.
+To verify our iPerf installation, first switch the context to the cluster with the iperf-sleep.yaml applied.
 
 ## Validating the iPerf Sleep Installation
 Perform these steps:

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/tutorials/deploying-the-iperf-application.mdx
@@ -18,7 +18,7 @@ see [Installing KubeSlice](/versioned_docs/version-0.3.0/getting-started-with-cl
   ```
   kubectl create ns iperf
   ```
-- You have the slice created across worker clusters. For more information, 
+- You have the slice created across the worker clusters. For more information, 
 see [Creating a Slice](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx).
 
 


### PR DESCRIPTION
Fixed minor typos in the tutorials:
- BookInfo
- Iperf