### PR TITLE
Fixed the next button issue in the kubeslice-cli overview

### DIFF
--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli.mdx
@@ -1,0 +1,6 @@
+# kubeslice-cli
+kubeslice-cli is a command-line tool that allows you to perform KubeSlice operations on 
+Kubernetes clusters. It simplifies the process to install and uninstall the workloads 
+needed to run KubeSlice Controller and Slice Operator in the specified clusters.
+This tool registers those clusters as part of a KubeSlice multi-cluster, and 
+administer slices across those clusters.

--- a/versioned_sidebars/version-0.4.0-sidebars.json
+++ b/versioned_sidebars/version-0.4.0-sidebars.json
@@ -111,7 +111,7 @@
        "collapsed": true,
        "link": {
           "type": "doc",
-          "id": "kubeslice-cli/kubeslice-cli-overview"
+          "id": "kubeslice-cli/kubeslice-cli"
           },
       "items": [ 
     "kubeslice-cli/kubeslice-cli-overview",


### PR DESCRIPTION
Fixed the next button issue in the kubeslice-cli overview by introducing an equivalent top-level topic. 