### PR TITLE
AM-5633 Update the command syntax

### DIFF
--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/create.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/create.mdx
@@ -5,9 +5,9 @@ service export.
 
 ## Syntax
 ```
-kubeslice-cli create [global options] <command> <command-options>
-kubeslice-cli create project <project-name> --namespace <controller-namespace>
-kubeslice-cli create <sliceConfig/serviceExportConfig> --namespace <project namespace> --filename <path-to-the-file/configuration-yaml>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
+kubeslice-cli --config <config-yaml-file> create project <project-name> --namespace <controller-namespace>
+kubeslice-cli create <sliceConfig|serviceExportConfig> --namespace <project-namespace> --filename <path-to-the-file/configuration-yaml>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/create.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/create.mdx
@@ -5,7 +5,6 @@ service export.
 
 ## Syntax
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli --config <config-yaml-file> create project <project-name> --namespace <controller-namespace>
 kubeslice-cli create <sliceConfig|serviceExportConfig> --namespace <project-namespace> --filename <path-to-the-file/configuration-yaml>
 ```

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/delete.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/delete.mdx
@@ -7,10 +7,9 @@ see [Uninstalling KubeSlice](/versioned_docs/version-0.x.0/kubeslice-cli/uninsta
 
 ## Syntax
 ```
-kubeslice-cli delete [global options] <command> <command-options>
-kubeslice-cli <remove/d> [global options] <command> <command-options>
-kubeslice-cli delete project <project-name> --namespace <controller-namespace>
-kubeslice-cli delete <sliceConfig/serviceExportConfig> <resource-name> --namespace <project namespace>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
+kubeslice-cli <delete|removed|d> project <project-name> --namespace <controller-namespace>
+kubeslice-cli <delete|removed|d> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/delete.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/delete.mdx
@@ -7,7 +7,6 @@ see [Uninstalling KubeSlice](/versioned_docs/version-0.x.0/kubeslice-cli/uninsta
 
 ## Syntax
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli <delete|removed|d> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <delete|removed|d> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
 ```

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/describe.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/describe.mdx
@@ -4,9 +4,9 @@ Use this command to describe KubeSlice resources. This shows the details of a sp
 
 ## Syntax
 ```
-kubeslice-cli describe [global options] <command> <command-options>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli describe project <project-name> --namespace <controller-namespace>
-kubeslice-cli describe <sliceConfig/serviceExportConfig> --namespace <project namespace>
+kubeslice-cli describe <sliceConfig|serviceExportConfig> --namespace <project-namespace>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/describe.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/describe.mdx
@@ -5,7 +5,7 @@ Use this command to describe KubeSlice resources. This shows the details of a sp
 ## Syntax
 ```
 kubeslice-cli describe project <project-name> --namespace <controller-namespace>
-kubeslice-cli describe <sliceConfig | serviceExportConfig> --namespace <project-namespace>
+kubeslice-cli describe <sliceConfig|serviceExportConfig> --namespace <project-namespace>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/describe.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/describe.mdx
@@ -4,9 +4,8 @@ Use this command to describe KubeSlice resources. This shows the details of a sp
 
 ## Syntax
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli describe project <project-name> --namespace <controller-namespace>
-kubeslice-cli describe <sliceConfig|serviceExportConfig> --namespace <project-namespace>
+kubeslice-cli describe <sliceConfig | serviceExportConfig> --namespace <project-namespace>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/edit.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/edit.mdx
@@ -9,9 +9,9 @@ of the resource, or update your temporary saved copy to include the latest resou
 
 ## Syntax
 ```
-kubeslice-cli <edit/e> [global options] <command> <command-options>
-kubeslice-cli edit project <project-name> --namespace <controller-namespace>
-kubeslice-cli edit <sliceConfig/serviceExportConfig> <resource-name> --namespace <project namespace>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
+kubeslice-cli <edit|e> project <project-name> --namespace <controller-namespace>
+kubeslice-cli <edit|e> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/edit.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/edit.mdx
@@ -9,7 +9,6 @@ of the resource, or update your temporary saved copy to include the latest resou
 
 ## Syntax
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli <edit|e> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <edit|e> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
 ```

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/get.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/get.mdx
@@ -5,7 +5,6 @@ service export.
 
 ## Syntax
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli <get|g> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <get|g> <sliceConfig|serviceExportConfig> --namespace <project-namespace>
 ```

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/get.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/get.mdx
@@ -5,9 +5,9 @@ service export.
 
 ## Syntax
 ```
-kubeslice-cli <get/g> [global options] <command> <command-options>
-kubeslice-cli get project <project-name> --namespace <controller-namespace>
-kubeslice-cli get <sliceConfig/serviceExportConfig> --namespace <project namespace>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
+kubeslice-cli <get|g> project <project-name> --namespace <controller-namespace>
+kubeslice-cli <get|g> <sliceConfig|serviceExportConfig> --namespace <project-namespace>
 ```
 ## Options
 The following are the `kubeslice-cli get` command options.

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/install.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/install.mdx
@@ -7,6 +7,7 @@ Use this command to install the required workloads to run KubeSlice Controller a
 ```
 kubeslice-cli --config <path-to-the-file/configuration-yaml> <install|i>
 kubeslice-cli install <command-options>
+kubeslice-cli install --profile=<minimal-demo|full-demo>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/install.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/install.mdx
@@ -5,7 +5,9 @@ Use this command to install the required workloads to run KubeSlice Controller a
 ## Syntax
 
 ```
-kubeslice-cli <install/i> [global options] <command> <command-options>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
+kubeslice-cli --config <path-to-the-file/configuration-yaml> <install|i>
+kubeslice-cli install <command-options>
 ```
 
 ## Options
@@ -32,5 +34,5 @@ The following are the example commands:
 
 2. To install the KubeSlice using topology file, use the following command:
    ```
-   kubeslice-cli install --config <path-to-the-topology-configuration.yaml> 
+   kubeslice-cli --config <path-to-the-topology-configuration.yaml> install
    ```

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/install.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/install.mdx
@@ -5,7 +5,6 @@ Use this command to install the required workloads to run KubeSlice Controller a
 ## Syntax
 
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli --config <path-to-the-file/configuration-yaml> <install|i>
 kubeslice-cli install <command-options>
 ```

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/kubeslice-cli-commands.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/kubeslice-cli-commands.mdx
@@ -47,8 +47,3 @@ following command to determine which context you are currently in: `kubectx -c`.
 - The currently supported operations are all controller cluster specific. You must run the kubeslice-cli commands on the controller cluster. 
 use this command to switch the cluster context: `kubectx <controller-cluster>`.
 :::
-
-:::info
-Currently, kubeslice-cli does not support ServiceExport. For information on how to deploy an application on a slice, see 
-[Managing Namespaces](/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/managing-namespaces.mdx).
-:::

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/kubeslice-cli-commands.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/kubeslice-cli-commands.mdx
@@ -6,7 +6,7 @@ This section contains information about KubeSlice commands, syntax, options, a r
 Use the following syntax to run the kubeslice-cli tool:
 
 ```
-kubeslice-cli [global options] <command> <command-options>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 ```
 
 ## Commands

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/register.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/register.mdx
@@ -5,7 +5,6 @@ Use this command to register a new worker cluster with the KubeSlice Controller 
 ## Syntax
 
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli register worker <worker-cluster-name> --namespace <project-namespace>
 ```
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/register.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/register.mdx
@@ -5,8 +5,8 @@ Use this command to register a new worker cluster with the KubeSlice Controller 
 ## Syntax
 
 ```
-kubeslice-cli register [global options] <command> <command-options>
-kubeslice-cli register worker <worker-cluster-name> --namespace <project namespace>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
+kubeslice-cli register worker <worker-cluster-name> --namespace <project-namespace>
 ```
 ## Options
 The following are the `kubeslice-cli register` command options.

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/uninstall.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/uninstall.mdx
@@ -5,8 +5,8 @@ Use this command to delete the kind clusters used for KubeSlice demonstration.
 ## Syntax
 
 ```
-kubeslice-cli uninstall [global options] <command> <command-options>
-kubeslice-cli cleanup [global options] <command> <command-options>
+kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
+kubeslice-cli <uninstall|cleanup>
 ```
 
 ## Options

--- a/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/uninstall.mdx
+++ b/versioned_docs/version-0.4.0/kubeslice-cli/kubeslice-cli-commands/uninstall.mdx
@@ -5,7 +5,6 @@ Use this command to delete the kind clusters used for KubeSlice demonstration.
 ## Syntax
 
 ```
-kubeslice-cli [global-options] <command> [<command-arguments>] [command-options]
 kubeslice-cli <uninstall|cleanup>
 ```
 


### PR DESCRIPTION
- updated the syntax for all the commands.
- Removed the info block:
 
:::info
Currently, kubeslice-cli does not support ServiceExport. For information on how to deploy an application on a slice, see 
[Managing Namespaces](/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/installing-kubeslice/managing-namespaces.mdx).
:::