### PR TITLE
Removed the note that claimed support for only AKS and GKE clusters

### DIFF
--- a/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx
+++ b/versioned_docs/version-0.2.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx
@@ -64,10 +64,6 @@ istiod-66f576dd98-jtshj       1/1     Running   0          100s
 The following information is required to create your cluster registration **.yaml** file.
 
 :::info
-Currently, only Azure Kubernetes Service (AKS) and Google Kubernetes Engine (GKE) are supported.
-:::
-
-:::info
 Register the worker clusters with the KubeSlice Controller by applying the YAML on the Project namespace.
 :::
 

--- a/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx
+++ b/versioned_docs/version-0.3.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx
@@ -64,10 +64,6 @@ istiod-66f576dd98-jtshj       1/1     Running   0          100s
 The following information is required to create your cluster registration **.yaml** file.
 
 :::info
-Currently, only Azure Kubernetes Service (AKS) and Google Kubernetes Engine (GKE) are supported.
-:::
-
-:::info
 Register the worker clusters with the KubeSlice Controller by applying the YAML on the Project namespace.
 :::
 

--- a/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx
+++ b/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx
@@ -64,10 +64,6 @@ istiod-66f576dd98-jtshj       1/1     Running   0          100s
 The following information is required to create your cluster registration **.yaml** file.
 
 :::info
-Currently, only Azure Kubernetes Service (AKS) and Google Kubernetes Engine (GKE) are supported.
-:::
-
-:::info
 Register the worker clusters with the KubeSlice Controller by applying the YAML on the Project namespace.
 :::
 


### PR DESCRIPTION
Removed the note that claimed support for only AKS and GKE clusters in all versions. 