### PR TITLE
AM-6257 - update known issue to the release notes

### DIFF
--- a/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.0.mdx
+++ b/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.0.mdx
@@ -34,6 +34,10 @@ of cluster registration by 120 seconds. The worker cluster can only be added to 
   
   Workaround: None
 
+- After a slice is created, the gateway connectivity takes approximately 120 seconds to establish a tunnel.
+ 
+  Workaround: None
+
 - Istio version 1.13 is incompatible with Kubernetes version 1.24. It might cause issues with KubeSlice version 0.5.0, which 
   now supports Kubernetes version 1.24. However, KubeSlice version 0.5.0 can be installed without Istio too.
   


### PR DESCRIPTION
updated the following known issue to the release notes
After a slice is created, the gateway connectivity takes approximately 120 seconds to establish a tunnel.