### PR TITLE
AM-6310: Update the kubeslice-cli uninstall command

### DIFF
--- a/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
+++ b/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
@@ -206,7 +206,6 @@ see [Uninstalling KubeSlice](/versioned_docs/version-0.5.0/kubeslice-cli/uninsta
 ```
 kubeslice-cli <delete|remove|d> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <delete|remove|d> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
-kubeslice-cli <delete|remove|d> --config=<path-to-the-custom-topology-file>
 ```
 
 ### Options
@@ -285,7 +284,6 @@ Use this command to describe KubeSlice resources. This shows the details of a sp
 ```
 kubeslice-cli describe project <project-name> --namespace <controller-namespace>
 kubeslice-cli describe <sliceConfig|serviceExportConfig> --namespace <project-namespace>
-kubeslice-cli describe --config=<path-to-the-custom-topology-file>
 ```
 
 ### Options
@@ -398,7 +396,6 @@ The following are the example commands:
    Events:                  <none>
    ```
 
-
 ## edit
 Use this command to directly edit any KubeSlice resource you can retrieve through the command line tools. It opens the 
 editor defined by your KUBE_EDITOR, or EDITOR environment variables, or falls back to `vi` for Linux or `notepad` for Windows. 
@@ -412,7 +409,6 @@ of the resource, or update your temporary saved copy to include the latest resou
 ```
 kubeslice-cli <edit|e> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <edit|e> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
-kubeslice-cli <edit|e> --config=<path-to-the-custom-topology-file>
 ```
 
 ### Options
@@ -487,7 +483,6 @@ service export.
 ```
 kubeslice-cli <get|g> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <get|g> <sliceConfig|serviceExportConfig> --namespace <project-namespace>
-kubeslice-cli <get|g> --config=<path-to-the-custom-topology-file>
 ```
 ### Options
 The following are the `kubeslice-cli get` command options.
@@ -645,7 +640,7 @@ The following are the example commands:
    kubectl-cli install --profile=minimal-demo
    ```
 
-2. To install the KubeSlice using topology file, use the following command:
+2. To install the KubeSlice using custom topology file, use the following command:
    ```
    kubeslice-cli --config <path-to-the-custom-topology-file> install
    ```
@@ -735,20 +730,20 @@ The following are the `kubeslice-cli uninstall` options
 ### Examples
 The following is an example command:
 
-1. To uninstall the KubeSlice components on kind clusters, use one of the following command:
-   :::info
-   The `kubeslice-cli uninstall` command is used to delete the kind clusters created for Kubeslice demo. The demo setup 
-   created using `kubeslice-cli install --profile=<minimal-demo|full-demo>` option. 
-   :::
-   
+1. To uninstall the KubeSlice components on kind clusters and delete the kind clusters created using `full-demo` option, 
+   use the following command:
    ```
    kubeslice-cli uninstall
    ```
+
+2. To uninstall the KubeSlice components on kind clusters and delete the kind clusters created using `minimal-demo` option,
+   use one of the following commands:
    ```
+   kubeslice-cli uninstall
    kubeslice-cli uninstall --profile=minimal-demo
    ```
 
-2. To uninstall the KubeSlice components that were installed using a custom topology file on cloud clusters, use the following command:
+3. To uninstall the KubeSlice components that were installed using a custom topology file on cloud clusters, use the following command:
 
    :::info
    KubeSlice must be uninstalled using the topology file that was used to install it on cloud clusters.

--- a/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
+++ b/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
@@ -702,7 +702,7 @@ Use this command to delete the kind clusters used for KubeSlice demonstration.
 ### Syntax
 
 ```
-kubeslice-cli <uninstall|cleanup>
+kubeslice-cli <uninstall|cleanup> [options]
 ```
 
 ### Options
@@ -712,6 +712,8 @@ The following are the `kubeslice-cli uninstall` options
 |----|----|----|
 |--config|-c|It is a **global** option. The path to the topology configuration YAML file.|
 |--help|-h|It provides information on the delete command.|
+|--all|-a|Uninstalls all the KubeSlice components (worker, controller, and UI).|
+|--ui|-u|Uninstalls the enterprise user interface component (Kubeslice-Manager).|
 
 ### Examples
 The following is an example command:
@@ -724,4 +726,9 @@ created using `kubeslice-cli install --profile` option.
    
    ```
    kubeslice-cli uninstall
+   ```
+
+2. To uninstall the KubeSlice Controller and its component, use the following command:
+   ```
+   kubeslice-cli uninstall --config=file-path-of-topology --all
    ```

--- a/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
+++ b/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
@@ -126,8 +126,8 @@ service export.
 
 ### Syntax
 ```
-kubeslice-cli --config <config-yaml-file> create project <project-name> --namespace <controller-namespace>
-kubeslice-cli create <sliceConfig|serviceExportConfig> --namespace <project-namespace> --filename <path-to-the-file/configuration-yaml>
+kubeslice-cli --config <path-to-the-custom-topology-file> create project <project-name> --namespace <controller-namespace>
+kubeslice-cli create <sliceConfig|serviceExportConfig> --namespace <project-namespace> --filename <path-to-the-configuration-yaml>
 ```
 
 ### Options
@@ -206,6 +206,7 @@ see [Uninstalling KubeSlice](/versioned_docs/version-0.5.0/kubeslice-cli/uninsta
 ```
 kubeslice-cli <delete|remove|d> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <delete|remove|d> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
+kubeslice-cli <delete|remove|d> --config=<path-to-the-custom-topology-file>
 ```
 
 ### Options
@@ -284,6 +285,7 @@ Use this command to describe KubeSlice resources. This shows the details of a sp
 ```
 kubeslice-cli describe project <project-name> --namespace <controller-namespace>
 kubeslice-cli describe <sliceConfig|serviceExportConfig> --namespace <project-namespace>
+kubeslice-cli describe --config=<path-to-the-custom-topology-file>
 ```
 
 ### Options
@@ -410,6 +412,7 @@ of the resource, or update your temporary saved copy to include the latest resou
 ```
 kubeslice-cli <edit|e> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <edit|e> <sliceConfig|serviceExportConfig> <resource-name> --namespace <project-namespace>
+kubeslice-cli <edit|e> --config=<path-to-the-custom-topology-file>
 ```
 
 ### Options
@@ -484,6 +487,7 @@ service export.
 ```
 kubeslice-cli <get|g> project <project-name> --namespace <controller-namespace>
 kubeslice-cli <get|g> <sliceConfig|serviceExportConfig> --namespace <project-namespace>
+kubeslice-cli <get|g> --config=<path-to-the-custom-topology-file>
 ```
 ### Options
 The following are the `kubeslice-cli get` command options.
@@ -614,7 +618,7 @@ Use this command to install the required workloads to run KubeSlice Controller a
 ### Syntax
 
 ```
-kubeslice-cli --config <path-to-the-file/configuration-yaml> <install|i>
+kubeslice-cli --config <path-to-the-custom-topology-file> <install|i>
 kubeslice-cli install <command-options>
 kubeslice-cli install --profile=<minimal-demo|full-demo>
 ```
@@ -643,7 +647,7 @@ The following are the example commands:
 
 2. To install the KubeSlice using topology file, use the following command:
    ```
-   kubeslice-cli --config <path-to-the-topology-configuration.yaml> install
+   kubeslice-cli --config <path-to-the-custom-topology-file> install
    ```
 
 ## register
@@ -654,6 +658,7 @@ Use this command to register a new worker cluster with the KubeSlice Controller 
 
 ```
 kubeslice-cli register worker <worker-cluster-name> --namespace <project-namespace>
+kubeslice-cli --config <path-to-the-custom-topology-file> <install|i> [options]
 ```
 ### Options
 The following are the `kubeslice-cli register` command options.
@@ -677,7 +682,7 @@ The following are the example commands:
 You must switch the context to the controller cluster to register the worker cluster.
 :::
 
-1. To register a worker cluster with the KubeSlice Controller in demo setup, use the following command:
+1. To register a new worker cluster with the KubeSlice Controller in demo setup, use the following command:
    ```
    kubeslice-cli register worker <worker-cluster-name> -n kubeslice-demo
    ```
@@ -694,15 +699,27 @@ You must switch the context to the controller cluster to register the worker clu
    Registered Worker Clusters with Project.
    ```
 
+2. To register a new worker cluster with the KubeSlice Controller in an existing multi-cluster setup, use the following command:
+   :::info
+   Add a new worker information in the same custom topology file that you used to install KubeSlice. The **-s controller** 
+   option skips the installation of KubeSlice Controller.
+   :::
+   
+   ```
+   kubeslice-cli --config=<path-to-the-custom-topology-file> install -s controller
+   ```
+
 
 ## uninstall
 
-Use this command to delete the kind clusters used for KubeSlice demonstration.
+Use this command to uninstall all the KubeSlice components on kind and cloud clusters.
 
 ### Syntax
 
 ```
-kubeslice-cli <uninstall|cleanup> [options]
+kubeslice-cli <uninstall|cleanup>
+kubeslice-cli <uninstall|cleanup> --config=<path-to-the-custom-topology-file> [options]
+kubeslice-cli <uninstall|cleanup> --profile=minimal-demo
 ```
 
 ### Options
@@ -712,23 +729,30 @@ The following are the `kubeslice-cli uninstall` options
 |----|----|----|
 |--config|-c|It is a **global** option. The path to the topology configuration YAML file.|
 |--help|-h|It provides information on the delete command.|
-|--all|-a|Uninstalls all the KubeSlice components (worker, controller, and UI).|
-|--ui|-u|Uninstalls the enterprise user interface component (Kubeslice-Manager).|
+|--all|-a|Uninstalls all the KubeSlice components (worker, controller, and Kubeslice Manager).|
+|--ui|-u|Uninstalls the enterprise user interface component (Kubeslice Manager).|
 
 ### Examples
 The following is an example command:
-:::info
-The `kubeslice-cli uninstall` command is used to delete the kind clusters created for Kubeslice demo. The demo setup 
-created using `kubeslice-cli install --profile` option. 
-:::
 
-1. To uninstall the KubeSlice Controller and its components, use the following command:
+1. To uninstall the KubeSlice components on kind clusters, use one of the following command:
+   :::info
+   The `kubeslice-cli uninstall` command is used to delete the kind clusters created for Kubeslice demo. The demo setup 
+   created using `kubeslice-cli install --profile=<minimal-demo|full-demo>` option. 
+   :::
    
    ```
    kubeslice-cli uninstall
    ```
-
-2. To uninstall the KubeSlice Controller and its component, use the following command:
    ```
-   kubeslice-cli uninstall --config=file-path-of-topology --all
+   kubeslice-cli uninstall --profile=minimal-demo
+   ```
+
+2. To uninstall the KubeSlice components that were installed using a custom topology file on cloud clusters, use the following command:
+
+   :::info
+   KubeSlice must be uninstalled using the topology file that was used to install it on cloud clusters.
+   :::4
+   ```
+   kubeslice-cli uninstall --config=<path-to-the-custom-topology-file> --all
    ```

--- a/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
+++ b/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
@@ -58,7 +58,7 @@ sudo curl -fL https://github.com/kubeslice/kubeslice-cli/releases/download/<late
 
 Example
 ```
-sudo curl -fL https://github.com/kubeslice/kubeslice-cli/releases/download/0.3.2/kubeslice-cli-linux-amd64 -o /usr/local/bin/kubeslice-cli
+sudo curl -fL https://github.com/kubeslice/kubeslice-cli/releases/download/0.4.0/kubeslice-cli-0.4.0-linux-amd64 -o  -o /usr/local/bin/kubeslice-cli
 ```
 Make the binary executable using the following command:
 ```

--- a/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
+++ b/versioned_docs/version-0.5.0/kubeslice-cli/getting-started.mdx
@@ -58,7 +58,7 @@ sudo curl -fL https://github.com/kubeslice/kubeslice-cli/releases/download/<late
 
 Example
 ```
-sudo curl -fL https://github.com/kubeslice/kubeslice-cli/releases/download/0.4.0/kubeslice-cli-0.4.0-linux-amd64 -o  -o /usr/local/bin/kubeslice-cli
+sudo curl -fL https://github.com/kubeslice/kubeslice-cli/releases/download/0.4.0/kubeslice-cli-0.4.0-linux-amd64 -o /usr/local/bin/kubeslice-cli
 ```
 Make the binary executable using the following command:
 ```
@@ -713,8 +713,6 @@ Use this command to uninstall all the KubeSlice components on kind and cloud clu
 
 ```
 kubeslice-cli <uninstall|cleanup>
-kubeslice-cli <uninstall|cleanup> --config=<path-to-the-custom-topology-file> [options]
-kubeslice-cli <uninstall|cleanup> --profile=minimal-demo
 ```
 
 ### Options
@@ -730,24 +728,17 @@ The following are the `kubeslice-cli uninstall` options
 ### Examples
 The following is an example command:
 
-1. To uninstall the KubeSlice components on kind clusters and delete the kind clusters created using `full-demo` option, 
+1. To uninstall the KubeSlice components on kind clusters and delete the kind clusters created using `full-demo|minimal-demo` option, 
    use the following command:
    ```
    kubeslice-cli uninstall
    ```
 
-2. To uninstall the KubeSlice components on kind clusters and delete the kind clusters created using `minimal-demo` option,
-   use one of the following commands:
-   ```
-   kubeslice-cli uninstall
-   kubeslice-cli uninstall --profile=minimal-demo
-   ```
-
-3. To uninstall the KubeSlice components that were installed using a custom topology file on cloud clusters, use the following command:
+2. To uninstall the KubeSlice components that were installed using a custom topology file on cloud clusters, use the following command:
 
    :::info
    KubeSlice must be uninstalled using the topology file that was used to install it on cloud clusters.
-   :::4
+   :::
    ```
    kubeslice-cli uninstall --config=<path-to-the-custom-topology-file> --all
    ```

--- a/versioned_docs/version-0.5.0/kubeslice-cli/installing-kubeslice.mdx
+++ b/versioned_docs/version-0.5.0/kubeslice-cli/installing-kubeslice.mdx
@@ -26,18 +26,18 @@ You must create a topology configuration file that includes the names of the clu
 that host the KubeSlice Controller and the worker clusters. For more information, see sample 
 [topology configuration](/versioned_docs/version-0.5.0/reference/sample-configuration-file.mdx) file.
 
-Use the following command to install the controller and worker cluster:
+Use the following command to install the KubeSlice Controller and worker cluster(s):
 ```
-kubeslice-cli --config=<topology-configuration-file> install
+kubeslice-cli --config=<path-to-custom-topology-file> install
 ```
-The above command installs the KubeSlice Controller, creates a project, and registers the worker cluster with the project by installing the Slice
-Operator on the worker cluster.
+The above command installs the KubeSlice Controller, creates a project, and registers the worker cluster with the project 
+by installing the Slice Operator on the worker cluster.
 
 ## Register a Worker Cluster
 
 The kubeslice-cli allows you to add a new worker cluster to an existing KubeSlice configuration.
 
-Use the following template to add a new worker cluster.
+Use the following topology template to add a new worker cluster.
 
 ```yaml
 
@@ -54,7 +54,8 @@ configuration:
   kubeslice_configuration:
     project_name: <project-namespace>
 ```
-The following is an example topology file for registering a new worker cluster.
+
+The following is an example custom topology file for registering a new worker cluster.
 ```yaml
 configuration:
   cluster_configuration:

--- a/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
+++ b/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
@@ -25,7 +25,7 @@ The latest Kubernetes version that we support from this release is version [1.24
   ensures that all the worker clusters that are part of a slice will have that 
   namespace for which the namespace sameness is applied. This created namespace remains on the worker 
   cluster even after the worker cluster is detached from that slice, and even when that slice is deleted.
-* `kubeslice-cli` tool now supports uninstalling the Kubeslice components on cloud clusters using custom topology file.
+* The **kubeslice-cli** tool now allows you to uninstall Kubeslice components using a custom topology file.
 
 ## Known Issues
 The known issues are as follows:

--- a/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
+++ b/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
@@ -1,4 +1,4 @@
-# Release Notes for KubeSlice OSS 0.5.1
+# Release Notes for KubeSlice OSS 0.5.0 v1
 
 *Release date: 06 Jan 2023*
 
@@ -20,31 +20,4 @@ The Network Service Mesh (NSM) component has been upgraded to the stable
 The latest Kubernetes version that we support from this release is version [1.24](https://v1-24.docs.kubernetes.io/). 
 
 ### Enhancements 
-* When the **namespace sameness** is applied to a namespace on a slice, then it applies to all worker 
-  clusters that are part of the slice. If a worker cluster does not already have that namespace, it is now created. This 
-  ensures that all the worker clusters that are part of a slice will have that 
-  namespace for which the namespace sameness is applied. This created namespace remains on the worker 
-  cluster even after the worker cluster is detached from that slice, and even when that slice is deleted.
 * The **kubeslice-cli** tool now allows you to uninstall Kubeslice components using a custom topology file.
-
-## Known Issues
-The known issues are as follows:
-
-- If the SPIRE server takes time to start up, the **spire-server** pod continues to restart, thus delaying the completion 
-of cluster registration by 120 seconds. The worker cluster can only be added to a slice after this.
-  
-  Workaround: None
-
-- After a slice is created, the gateway connectivity takes approximately 120 seconds to establish a tunnel.
- 
-  Workaround: None
-
-- Istio version 1.13 is incompatible with Kubernetes version 1.24. It might cause issues with KubeSlice version 0.5.0, which 
-  now supports Kubernetes version 1.24. However, KubeSlice version 0.5.0 can be installed without Istio too.
-  
-  Workaround: In the following topics, you must skip the steps related to Istio:
-
-  * [Prerequisites](/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/prerequisites/prerequisites.mdx)
-  * [Register the worker cluster](/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx)
-  * [Create a slice](/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx)
-  * [Deploy the BookInfo application](/versioned_docs/version-0.4.0/tutorials/deploying-the-bookinfo-application.mdx)

--- a/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
+++ b/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
@@ -13,4 +13,4 @@ We continue to add new features and enhancements to KubeSlice.
 These release notes describe the new changes and enhancements in this version.
 
 ### Enhancements 
-* The **kubeslice-cli** tool now allows you to uninstall Kubeslice components using a custom topology file.
+* The **kubeslice-cli** tool now allows uninstalling Kubeslice components using a custom topology file.

--- a/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
+++ b/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
@@ -1,0 +1,50 @@
+# Release Notes for KubeSlice OSS 0.5.1
+
+*Release date: 06 Jan 2023*
+
+KubeSlice is a ***cloud-independent*** platform that combines network, application, Kubernetes, and deployment services 
+in a framework to accelerate application deployment in a multi-cluster and multi-tenant environment. KubeSlice achieves this 
+by creating logical application ***slice*** boundaries that enable seamless communication between pods and services across 
+clusters, clouds, edges, and data centers.
+
+We continue to add new features and enhancements to KubeSlice. 
+
+## What's New
+These release notes describe the new changes and enhancements in this version.
+
+### Network Service Mesh Upgrade 
+The Network Service Mesh (NSM) component has been upgraded to the stable 
+[GA version 1.5.0](https://networkservicemesh.io/docs/releases/v1.5.0/) that provides upstream networking fixes. 
+
+### Latest Supported Kubernetes Version 
+The latest Kubernetes version that we support from this release is version [1.24](https://v1-24.docs.kubernetes.io/). 
+
+### Enhancements 
+* When the **namespace sameness** is applied to a namespace on a slice, then it applies to all worker 
+  clusters that are part of the slice. If a worker cluster does not already have that namespace, it is now created. This 
+  ensures that all the worker clusters that are part of a slice will have that 
+  namespace for which the namespace sameness is applied. This created namespace remains on the worker 
+  cluster even after the worker cluster is detached from that slice, and even when that slice is deleted.
+* `kubeslice-cli` tool now supports uninstalling the Kubeslice components on cloud clusters using custom topology file.
+
+## Known Issues
+The known issues are as follows:
+
+- If the SPIRE server takes time to start up, the **spire-server** pod continues to restart, thus delaying the completion 
+of cluster registration by 120 seconds. The worker cluster can only be added to a slice after this.
+  
+  Workaround: None
+
+- After a slice is created, the gateway connectivity takes approximately 120 seconds to establish a tunnel.
+ 
+  Workaround: None
+
+- Istio version 1.13 is incompatible with Kubernetes version 1.24. It might cause issues with KubeSlice version 0.5.0, which 
+  now supports Kubernetes version 1.24. However, KubeSlice version 0.5.0 can be installed without Istio too.
+  
+  Workaround: In the following topics, you must skip the steps related to Istio:
+
+  * [Prerequisites](/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/prerequisites/prerequisites.mdx)
+  * [Register the worker cluster](/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/installing-kubeslice/registering-the-worker-cluster.mdx)
+  * [Create a slice](/versioned_docs/version-0.4.0/getting-started-with-cloud-clusters/installing-kubeslice/creating-a-slice.mdx)
+  * [Deploy the BookInfo application](/versioned_docs/version-0.4.0/tutorials/deploying-the-bookinfo-application.mdx)

--- a/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
+++ b/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
@@ -12,8 +12,5 @@ We continue to add new features and enhancements to KubeSlice.
 ## What's New
 These release notes describe the new changes and enhancements in this version.
 
-### Latest Supported Kubernetes Version 
-The latest Kubernetes version that we support from this release is version [1.24](https://v1-24.docs.kubernetes.io/). 
-
 ### Enhancements 
 * The **kubeslice-cli** tool now allows you to uninstall Kubeslice components using a custom topology file.

--- a/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
+++ b/versioned_docs/version-0.5.0/release-notes/release-notes-for-kubeslice-oss-0.5.1.mdx
@@ -12,10 +12,6 @@ We continue to add new features and enhancements to KubeSlice.
 ## What's New
 These release notes describe the new changes and enhancements in this version.
 
-### Network Service Mesh Upgrade 
-The Network Service Mesh (NSM) component has been upgraded to the stable 
-[GA version 1.5.0](https://networkservicemesh.io/docs/releases/v1.5.0/) that provides upstream networking fixes. 
-
 ### Latest Supported Kubernetes Version 
 The latest Kubernetes version that we support from this release is version [1.24](https://v1-24.docs.kubernetes.io/). 
 

--- a/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
+++ b/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
@@ -155,12 +155,12 @@ Ensure to wait for the slice to complete the initialization before deploying ser
 
 To apply the slice configuration YAML, use the following command:
 ```
-kubeslice-cli create sliceConfig -n <project-namespace> -f <slice-configuration-yaml>
+kubeslice-cli create sliceConfig -n <project-namespace> -f <slice-configuration-yaml> --config=<path-to-the-custom-topology-file>
 ```
    
 Example
 ```
-kubeslice-cli create sliceConfig -n kubeslice-avesha -f slice-config.yaml
+kubeslice-cli create sliceConfig -n kubeslice-avesha -f slice-config.yaml 
 ```
    
 Example output
@@ -179,7 +179,7 @@ If the application is already deployed on a namespace that is onboarded to a sli
 ## Create a Service Export
 To create a service export, use the following command:
 ```
-kubeslice-cli create serviceExportConfig -f <service-export-yaml> -n <project-namespace>
+kubeslice-cli create serviceExportConfig -f <service-export-yaml> -n <project-namespace>  --config=<path-to-the-custom-topology-file>
 ```
 
 ### Validate the Service Export
@@ -242,7 +242,7 @@ the value and save. This updates the ServiceExportConfig. The ServiceExportConfi
 
 To edit the service export configuration, use the following command:
 ```
-kubeslice-cli edit serviceExportConfig <resource-name> -n <project-namespace>
+kubeslice-cli edit serviceExportConfig <resource-name> -n <project-namespace> --config=<path-to-the-custom-topology-file>
 ```
 Example
 ```

--- a/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
+++ b/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
@@ -225,4 +225,10 @@ Editing KubeSlice serviceExportConfig...
 
 ## Uninstall KubeSlice
 
-To uninstall KubeSlice from your cloud clusters, follow the instructions in [Uninstall KubeSlice](/versioned_docs/version-0.5.0/kubeslice-cli/uninstalling-kubeslice.mdx).
+To uninstall KubeSlice use the following command:
+```
+kubeslice-cli uninstall --config=<file-path-of-topology> --all
+```
+
+
+To uninstall KubeSlice from your cloud clusters step-by-step, follow the instructions in [Uninstall KubeSlice](/versioned_docs/version-0.5.0/kubeslice-cli/uninstalling-kubeslice.mdx).

--- a/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
+++ b/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
@@ -25,7 +25,35 @@ You must create a topology configuration file that includes the names of the clu
 KubeSlice Controller, the worker clusters, and a project name. For more information, see the sample 
 [topology configuration](/versioned_docs/version-0.5.0/reference/sample-configuration-file.mdx#create-a-topology-configuration-file-for-cloud-clusters) file.
 
-Use the following command to install the controller and the worker cluster:
+The following is an example custom topology file for installing KubeSlice in an existing setup.
+```
+configuration:
+  cluster_configuration:
+    kube_config_path: <path-to-the-kubeconfig-file>
+    controller:
+      name: controller
+      context_name: Cloud-controller
+      kube_config_path: <path-to-the-controller-kubeconfig-file>
+    workers:
+      - name: worker-1
+        context_name: cloud-worker-1
+      - name: worker-2
+        context_name: cloud-worker-2
+    kube_config_path: <path-to-the-worker-kubeconfig-file>
+  kubeslice_configuration:
+    project_name: kubeslice-avesha
+  helm_chart_configuration:
+    repo_alias: kubeslice
+    repo_url: https://kubeslice.github.io/kubeslice/
+    cert_manager_chart:
+      chart_name: cert-manager
+    controller_chart:
+      chart_name: kubeslice-controller
+    worker_chart:
+      chart_name: kubeslice-worker
+```
+
+Use the following command to install the controller and the worker clusters:
 ```
 kubeslice-cli --config=<topology-configuration-file> install
 ```
@@ -36,36 +64,40 @@ installing the Slice Operator on the worker cluster.
 
 The kubeslice-cli allows you to add a new worker cluster to an existing KubeSlice configuration.
 
-Use the following template to add a new worker cluster.
+:::note
+Add new worker cluster information to the custom topology file that was used to install KubeSlice earlier and 
+using **install** command, register the new worker cluster with the KubeSlice controller.
+:::
 
+The following is an example custom topology file for registering a new worker cluster.
 ```
 configuration:
   cluster_configuration:
-    kube_config_path: <kubeconfig-file>
-    controller:
-      name: <controller-cluster-name>
-      context_name: <controller-cluster-context>
-    workers:
-      - name: <new-worker-cluster-name>
-        context_name: <new-worker-cluster-context>
-  kubeslice_configuration:
-    project_name: <project-namespace>
-```
-The following is an example topology file for registering a new worker cluster.
-```
-configuration:
-  cluster_configuration:
-    kube_config_path: <PATH-TO-KUBECONFIG>
+    kube_config_path: <path-to-the-kubeconfig-file>
     controller:
       name: controller
       context_name: kind-controller
+      kube_config_path: <path-to-the-controller-kubeconfig-file>
     workers:
+      - name: worker-1
+        context_name: cloud-worker-1
+      - name: worker-2
+        context_name: cloud-worker-2
       - name: worker-3
-        context_name: cloud-cluster-3      
+        context_name: cloud-worker-3    
+    kube_config_path: <path-to-the-worker-kubeconfig-file>
   kubeslice_configuration:
-    project_name: avesha
-  ```
-
+    project_name: kubeslice-avesha
+  helm_chart_configuration:
+    repo_alias: kubeslice
+    repo_url: https://kubeslice.github.io/kubeslice/
+    cert_manager_chart:
+      chart_name: cert-manager
+    controller_chart:
+      chart_name: kubeslice-controller
+    worker_chart:
+      chart_name: kubeslice-worker
+```
 
 Use the following command to register a new worker cluster with the KubeSlice Controller:
 ```

--- a/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
+++ b/versioned_docs/version-0.5.0/tutorials/kubeslice-cli-demo-on-cloud-clusters.mdx
@@ -225,7 +225,7 @@ Editing KubeSlice serviceExportConfig...
 
 ## Uninstall KubeSlice
 
-To uninstall KubeSlice use the following command:
+To uninstall KubeSlice Controller and all its components, use the following command:
 ```
 kubeslice-cli uninstall --config=<file-path-of-topology> --all
 ```

--- a/versioned_sidebars/version-0.5.0-sidebars.json
+++ b/versioned_sidebars/version-0.5.0-sidebars.json
@@ -152,6 +152,7 @@
       "label": "RELEASE NOTES",
       "collapsed": true,
       "items": [
+        "release-notes/release-notes-for-kubeslice-oss-0.5.1",
         "release-notes/release-notes-for-kubeslice-oss-0.5.0",
         "release-notes/release-notes-for-kubeslice-oss-0.4.0",
         "release-notes/release-notes-for-kubeslice-oss-0.3.0",


### PR DESCRIPTION
Updated the following topics

- kubeslice-cli > Getting started (getting-started.mdx).
  updated syntax and example
- Tutorials > Demo using Cloud Clusters (kubeslice-cli-demo-on-cloud-clusters.mdx)
- Release notes > release-notes-for-kubeslice-oss-0.5.1