### PR TITLE
Update prod Dockerfile with multi-stage Docker build to serve website through nginx

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -6,4 +6,4 @@ services:
       dockerfile: prod.dockerfile
     restart: always
     ports:
-      - "3000:3000"
+      - "80:80"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,46 @@
+events {
+    worker_connections 1024;
+}
+
+worker_processes auto;
+
+http {
+    include /etc/nginx/mime.types;
+    
+    server {
+        listen 80;
+        root /usr/share/nginx/html;
+        index index.html;
+        
+        # Enable gzip
+        gzip on;
+        gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml application/font-woff application/font-woff2;
+        
+        rewrite ^/documentation/open-source/(.*)$ /$1 last;
+        
+        # handle redirection from root
+        location = / {
+            return 301 /documentation/open-source/1.4.0/;
+        }
+
+        location / {
+            try_files $uri $uri/ $uri/index.html /1.4.0/index.html;
+        }
+
+        # Cache static assets with fingerprints for 1 yr (Docusaurus adds hashes)
+        location ~* \.[a-f0-9]+\.(js|css)$ {
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+        
+        # Cache images and fonts for shorter time i.e. 7 days
+        location ~* \.(png|jpg|gif|ico|svg|woff|woff2)$ {
+            add_header Cache-Control "public, max-age=604800";
+        }
+        
+        # Don't cache HTML files
+        # This will now work correctly with the rewritten URI.
+        location ~* \.html$ {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+        }
+    }
+}

--- a/prod.dockerfile
+++ b/prod.dockerfile
@@ -1,11 +1,13 @@
-FROM node:18.2.0-alpine as builder
+FROM node:18.2.0-alpine AS builder
 WORKDIR /build
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm install
+RUN npm ci
 COPY . ./
 RUN npm run build
 
-EXPOSE 3000
-ENTRYPOINT ["npm", "run"]
-CMD ["serve"]
+FROM nginx:stable-alpine
+COPY --from=builder /build/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/kubeslice/docs/blob/master/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/kubeslice/docs/blob/master/code_of_conduct.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a KubeSlice Team member before any CI builds will run.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Upgrades
- [ ] Documentation Update

## Description
This PR enhances the current `prod.dockerfile` to use multi-stage build and serve the static build using `nginx` server. The image size was reduced from **957 MB** to **107 MB**. For serving the website correctly using nginx, a new `nginx.conf` is also introduced with minimal yet proper functional configuration.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings
Docker Image Size:
```shell
docker images
REPOSITORY                                                           TAG                    IMAGE ID       CREATED          SIZE
docs-multi-stage                                                     v6                     199dc439783c   36 minutes ago   107MB
docs-single-stage                                                    v1                     eba4e5bb637a   6 hours ago      957MB
```

#### Website Demo:

- RUN this command after Image Build:

```shell
docker run --rm -p 80:80 docs-multi-stage:v6
```
- Access the website at `http://localhost:80/`

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Color contrast tested?
